### PR TITLE
Remove assumptions about where viz params and assets live.

### DIFF
--- a/src/run_track_visualization.py
+++ b/src/run_track_visualization.py
@@ -18,8 +18,8 @@ def create_args():
                     type=str)
     cs.add_argument('--recording', default="26",
                     help="Name of the recording given by a number with a leading zero.", type=str)
-    cs.add_argument('--visualizer_params_dir', default="../data/visualizer_params/",
-                    help="Name of the recording given by a number with a leading zero.", type=str)
+    cs.add_argument('--visualizer_params_dir', default=None,
+                    help="Name of the visualizer params file given by a number with a leading zero.", type=str)
 
     # --- Visualization settings ---
     cs.add_argument('--playback_speed', default=4,
@@ -62,8 +62,12 @@ def create_args():
                     help="Show the track Visualizer maximized. Might affect performance.",
                     type=str2bool)
 
-    return vars(cs.parse_args())
-
+    # If no visualizer params directory provided, then append a default directory name to the dataset directory.
+    args = vars(cs.parse_args())
+    if args["visualizer_params_dir"] is None:
+        args["visualizer_params_dir"] = args["dataset_dir"] + "/visualizer_params/"
+    
+    return args
 
 def main():
     config = create_args()

--- a/src/run_track_visualization.py
+++ b/src/run_track_visualization.py
@@ -20,6 +20,7 @@ def create_args():
                     help="Name of the recording given by a number with a leading zero.", type=str)
     cs.add_argument('--visualizer_params_dir', default=None,
                     help="Name of the visualizer params file given by a number with a leading zero.", type=str)
+    cs.add_argument('--assets_dir', default=None, help="Path to the assets directory.", type=str)
 
     # --- Visualization settings ---
     cs.add_argument('--playback_speed', default=4,
@@ -62,11 +63,12 @@ def create_args():
                     help="Show the track Visualizer maximized. Might affect performance.",
                     type=str2bool)
 
-    # If no visualizer params directory provided, then append a default directory name to the dataset directory.
+    # If no visualizer params/assets directory provided, then append default directory names appropriately.
     args = vars(cs.parse_args())
     if args["visualizer_params_dir"] is None:
         args["visualizer_params_dir"] = args["dataset_dir"] + "/visualizer_params/"
-    
+    if args["assets_dir"] is None:
+        args["assets_dir"] = os.path.join(args["visualizer_params_dir"] , "assets/")
     return args
 
 def main():

--- a/src/track_visualizer.py
+++ b/src/track_visualizer.py
@@ -159,22 +159,23 @@ class TrackVisualizer(object):
         # Define the widgets
         self.textbox_frame = TextBox(self.ax_textbox, 'Set Frame ', initial=str(self.minimum_frame))
 
+        assets_dir = Path(config["assets_dir"])
         self.button_previous2 = Button(self.ax_button_previous2, '',
-                                       image=plt.imread("../assets/button_icons/previous2.png"))
+                                       image=plt.imread(assets_dir / "button_icons/previous2.png"))
         self.button_previous2.ax.axis('off')
 
         self.button_previous = Button(self.ax_button_previous, '',
-                                      image=plt.imread("../assets/button_icons/previous.png"))
+                                      image=plt.imread(assets_dir / "button_icons/previous.png"))
         self.button_previous.ax.axis('off')
 
-        self.button_next = Button(self.ax_button_next, '', image=plt.imread("../assets/button_icons/next.png"))
+        self.button_next = Button(self.ax_button_next, '', image=plt.imread(assets_dir / "button_icons/next.png"))
         self.button_next.ax.axis('off')
 
-        self.button_next2 = Button(self.ax_button_next2, '', image=plt.imread("../assets/button_icons/next2.png"))
+        self.button_next2 = Button(self.ax_button_next2, '', image=plt.imread(assets_dir / "button_icons/next2.png"))
         self.button_next2.ax.axis('off')
 
-        self.play_image = plt.imread("../assets/button_icons/play.png")
-        self.stop_image = plt.imread("../assets/button_icons/stop.png")
+        self.play_image = plt.imread(assets_dir / "button_icons/play.png")
+        self.stop_image = plt.imread(assets_dir / "button_icons/stop.png")
         self.button_play = Button(self.ax_button_play, '', image=self.play_image)
         self.button_play.ax.axis('off')
 


### PR DESCRIPTION
The visualizer currently assumes that assets like in ../assets, which prevents us from running this code from anywhere but the root directory of this repo. We generalize this by adding a CLI argument with a convenient default.

Since the datasets have `visualizer_params` folders, we do the same and add an argument for that file.

Replaces #8.